### PR TITLE
Fix out of order requests

### DIFF
--- a/packages/core/src/providers/chainState/chainStateReducer.ts
+++ b/packages/core/src/providers/chainState/chainStateReducer.ts
@@ -1,6 +1,6 @@
 import { ChainState } from './model'
 
-interface State {
+export interface State {
   [chainId: number]:
     | {
         blockNumber: number
@@ -30,9 +30,24 @@ export function chainStateReducer(state: State = {}, action: Action) {
   const current = state[action.chainId]?.blockNumber
   if (!current || action.blockNumber >= current) {
     if (action.type === 'FETCH_SUCCESS') {
+      let newState = action.state
+      if (action.blockNumber === current) {
+        // merge with existing state to prevent requests coming out of order
+        // from overwriting the data
+        const oldState = state[action.chainId]?.state ?? {}
+        for (const [address, entries] of Object.entries(oldState)) {
+          newState = {
+            ...newState,
+            [address]: {
+              ...entries,
+              ...newState[address],
+            },
+          }
+        }
+      }
       return {
         ...state,
-        [action.chainId]: { blockNumber: action.blockNumber, state: action.state },
+        [action.chainId]: { blockNumber: action.blockNumber, state: newState },
       }
     } else if (action.type === 'FETCH_ERROR') {
       return {

--- a/packages/core/test/reducers/chainStateReducer.test.ts
+++ b/packages/core/test/reducers/chainStateReducer.test.ts
@@ -1,0 +1,124 @@
+import { expect } from 'chai'
+import { chainStateReducer, State } from '../../src/providers/chainState/chainStateReducer'
+import { ChainId } from '../../src'
+
+describe('chainStateReducer', () => {
+  const ADDRESS_A = '0x' + 'a'.repeat(40)
+  const ADDRESS_B = '0x' + 'b'.repeat(40)
+  const ADDRESS_C = '0x' + 'c'.repeat(40)
+
+  it('ignores updates from older blocks', () => {
+    const state: State = {
+      [ChainId.Mainnet]: {
+        blockNumber: 1234,
+        state: {
+          [ADDRESS_A]: {
+            '0xdead': '0xbeef',
+          },
+        },
+      },
+    }
+    const result = chainStateReducer(state, {
+      type: 'FETCH_SUCCESS',
+      chainId: ChainId.Mainnet,
+      blockNumber: 1233,
+      state: {
+        [ADDRESS_A]: {
+          '0xdead': '0x0001',
+        },
+      },
+    })
+    expect(result).to.deep.equal(state)
+  })
+
+  it('overwrites with updates from newer blocks', () => {
+    const state: State = {
+      [ChainId.Mainnet]: {
+        blockNumber: 1234,
+        state: {
+          [ADDRESS_A]: {
+            '0xdead': '0xbeef',
+          },
+        },
+      },
+    }
+    const result = chainStateReducer(state, {
+      type: 'FETCH_SUCCESS',
+      chainId: ChainId.Mainnet,
+      blockNumber: 1235,
+      state: {
+        [ADDRESS_B]: {
+          '0xabcd': '0x5678',
+        },
+      },
+    })
+    const expected: State = {
+      [ChainId.Mainnet]: {
+        blockNumber: 1235,
+        state: {
+          [ADDRESS_B]: {
+            '0xabcd': '0x5678',
+          },
+        },
+      },
+    }
+    expect(result).to.deep.equal(expected)
+  })
+
+  it('merges updates from same block', () => {
+    // This behavior is needed to handle requests resolving out of order.
+    // Imagine the following calls are made:
+    //   a.foo()
+    //   b.bar()
+    // Then the user navigates to a different page and other calls are:
+    //   c.baz()
+    // This results in two multicall requests being made. Now imagine that
+    // they resolve out of order. Data for c.baz() then would be overwritten and
+    // the user would need to wait for the next block to see their data.
+    // To prevent this we merge the state for updates from the same block.
+    const state: State = {
+      [ChainId.Mainnet]: {
+        blockNumber: 1234,
+        state: {
+          [ADDRESS_A]: {
+            '0xdead': '0xbeef',
+          },
+          [ADDRESS_C]: {
+            '0xcc': '0xdd',
+          },
+        },
+      },
+    }
+    const result = chainStateReducer(state, {
+      type: 'FETCH_SUCCESS',
+      chainId: ChainId.Mainnet,
+      blockNumber: 1234,
+      state: {
+        [ADDRESS_A]: {
+          '0xabcd': '0x30',
+        },
+        [ADDRESS_B]: {
+          '0xabcd': '0x5678',
+        },
+      },
+    })
+    const expected: State = {
+      [ChainId.Mainnet]: {
+        blockNumber: 1234,
+        state: {
+          [ADDRESS_A]: {
+            '0xdead': '0xbeef',
+            '0xabcd': '0x30',
+          },
+          [ADDRESS_B]: {
+            '0xabcd': '0x5678',
+          },
+          [ADDRESS_C]: {
+            '0xcc': '0xdd',
+          },
+        },
+      },
+    }
+    expect(result).to.deep.equal(expected)
+  })
+})


### PR DESCRIPTION
When multicall requests made for the same block but for different chain calls resolve out of order the data gets overwritten. This PR fixes this by merging state in such cases.