### PR TITLE
Expose useConfig as public API

### DIFF
--- a/.changeset/lovely-jars-help.md
+++ b/.changeset/lovely-jars-help.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Expose useConfig as public API

--- a/packages/core/src/providers/config/index.ts
+++ b/packages/core/src/providers/config/index.ts
@@ -1,0 +1,2 @@
+export * from './context'
+export * from './provider'

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -1,6 +1,7 @@
 export * from './DAppProvider'
 export * from './blockNumber'
 export * from './chainState'
+export * from './config'
 export { useTransactionsContext } from './transactions/context'
 export { useNotificationsContext } from './notifications/context'
 export * from './transactions/model'


### PR DESCRIPTION
Isn't useConfig meant to be exposed according to the doc?
figured it isn't exported to the public except internally, at least according to Intellisense