### PR TITLE
isn't useConfig meant to be exposed

### DIFF
--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -1,6 +1,7 @@
 export * from './DAppProvider'
 export * from './blockNumber'
 export * from './chainState'
+export * from './config'
 export { useTransactionsContext } from './transactions/context'
 export { useNotificationsContext } from './notifications/context'
 export * from './transactions/model'


### PR DESCRIPTION
Isn't useConfig meant to be exposed according to the doc?
figured it isn't exported to the public except internally, at least according to Intellisense