### PR TITLE
Corrected useTokenBalance() arguments order

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -137,11 +137,11 @@ Provides a way to fetch balance of ERC20 token specified by ``tokenAddress`` for
 
   export function TokenBalance() {
     const { account } = useEthers()
-    const tokenBalance = useTokenBalance(account, DAI)
+    const tokenBalance = useTokenBalance(DAI, account)
 
     return (
       <div>
-        {tokenBalance && <p>Balance: {formatUnits(tokenBalance, 18)}</p>}
+        {tokenBalance && <p>Balance: {formatUnits(tokenBalance as any, 18)}</p>}
       </div>
     )
   }

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -141,7 +141,7 @@ Provides a way to fetch balance of ERC20 token specified by ``tokenAddress`` for
 
     return (
       <div>
-        {tokenBalance && <p>Balance: {formatUnits(tokenBalance as any, 18)}</p>}
+        {tokenBalance && <p>Balance: {formatUnits(tokenBalance, 18)}</p>}
       </div>
     )
   }


### PR DESCRIPTION
In Core API hook is documented correctly, only there was an error.