### PR TITLE
rename git repo link from dapp-framework to useDApp

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "main": "dist/cjs/src/index.js",
   "module": "dist/esm/src/index.js",
   "types": "dist/esm/src/index.d.ts",
-  "repository": "git@github.com:EthWorks/dapp-framework.git",
+  "repository": "git@github.com:EthWorks/useDApp.git",
   "author": "Ethworks",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.6",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
-  "repository": "git@github.com:EthWorks/dapp-framework.git",
+  "repository": "git@github.com:EthWorks/useDApp.git",
   "author": "Ethworks",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
minor fix to show the correct repo link in NPM https://www.npmjs.com/package/@usedapp/core (current link will redirect to the correct one though)