### PR TITLE
Fix return type of `activateBrowserWallet`

### DIFF
--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -287,7 +287,7 @@ Returns connection state and functions that allow to manipulate the state.
     - ``chainId: ChainId`` - current chainId (or *undefined* if not connected)
     - ``library: Web3Provider`` - an instance of ethers `Web3Provider <https://github.com/EthWorks/useDapp/tree/master/packages/example>`_ (or *undefined* if not connected)
     - ``active: boolean`` - returns if provider is connected (read or write mode)
-    - ``activateBrowserWallet()`` - function that will initiate connection to browser web3 extension (e.g. Metamask)
+    - ``activateBrowserWallet(onError?: (error: Error) => void, throwErrors?: boolean)`` - function that will initiate connection to browser web3 extension (e.g. Metamask)
     - ``async activate(connector: AbstractConnector, onError?: (error: Error) => void, throwErrors?: boolean)`` - function that allows to connect to a wallet
     - ``async deactivate()`` - function that disconnects wallet
     - ``error?: Error`` - an error that occurred during connecting (e.g. connection is broken, unsupported network)

--- a/packages/core/src/hooks/useEthers.ts
+++ b/packages/core/src/hooks/useEthers.ts
@@ -5,17 +5,19 @@ import { useCallback } from 'react'
 import { useConfig } from '../providers/config/context'
 import { InjectedConnector } from '@web3-react/injected-connector'
 
+type ActivateBrowserWallet = (onError?: (error: Error) => void, throwErrors?: boolean) => void
+
 export type Web3Ethers = ReturnType<typeof useWeb3React> & {
   library?: Web3Provider
   chainId?: ChainId
-  activateBrowserWallet: () => void
+  activateBrowserWallet: ActivateBrowserWallet
 }
 
 export function useEthers(): Web3Ethers {
   const result = useWeb3React<Web3Provider>()
   const { supportedChains } = useConfig()
-  const activateBrowserWallet = useCallback(
-    async (onError?: (error: Error) => void, throwErrors?: boolean) => {
+  const activateBrowserWallet = useCallback<ActivateBrowserWallet>(
+    async (onError, throwErrors) => {
       const injected = new InjectedConnector({ supportedChainIds: supportedChains })
       if (onError instanceof Function) {
         await result.activate(injected, onError, throwErrors)


### PR DESCRIPTION
`activateBrowserWallet` in `useEthers` hook didn't have the proper typing for the function signature. The params `(onError?: (error: Error) => void, throwErrors?: boolean)` were missing.

Docs updated as well