### PR TITLE
Fixed dependency issue when installing applications dependencies

### DIFF
--- a/.changeset/sweet-apes-accept.md
+++ b/.changeset/sweet-apes-accept.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': patch
+---
+
+Fixed dependency issue when installing applications dependencies

--- a/packages/core/src/hooks/useGasPrice.ts
+++ b/packages/core/src/hooks/useGasPrice.ts
@@ -1,4 +1,4 @@
-import { useBlockNumber } from '@usedapp/core/src/providers'
+import { useBlockNumber } from '../providers/blockNumber/context'
 import { BigNumber } from 'ethers'
 import { useEffect, useState } from 'react'
 import { useEthers } from './useEthers'


### PR DESCRIPTION
Hi, I ran into some issues with newer versions of useDApp in my application when trying to install dependencies. Javascript/node is not my strength so I'm not 100% sure why it failed and why my fix works, hopefully this works for everyone. My guess is that the import was resolving to node installed packages instead of resolving to the current file in src