### PR TITLE
Improve docs readability 

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -13,7 +13,26 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-  font-size: 32px;
+  font-size: 36px;
+  padding-left: -10px;
+}
+
+h2 {
+  font-size: 30px;
+  padding-top: 30px;
+  padding-left: -10px;
+}
+
+h3 {
+  font-size: 20px;
+  padding-top: 5px;
+  margin-left: -10px;
+  margin-top: 40px;
+  border-top: 2px solid rgba(181,181,181,0.43);
+}
+
+section {
+  padding-left: 10px;
 }
 
 .caption-text {


### PR DESCRIPTION
As of now it's hard to tell at a glance where one subject ends and where the other begins in docs. This PR is a proposition of improving readability. Opinions and propositions are welcome about how to improve it.
<img width="960" alt="Screenshot 2021-05-31 at 14 59 54" src="https://user-images.githubusercontent.com/38212223/120197212-047de180-c221-11eb-979f-099d0523a791.png">
