### PR TITLE
(coingecko) add readme

### DIFF
--- a/packages/coingecko/README.md
+++ b/packages/coingecko/README.md
@@ -1,0 +1,17 @@
+# @useDapp/coingecko
+
+### Ethereum 🤝 React
+
+React hook to get token price from CoinGecko
+
+## Documentation
+
+For detailed feature walkthrough checkout [documentation](https://usedapp.readthedocs.io/en/latest/coingecko.html).
+
+## Contributing
+
+Contributions are always welcome, no matter how large or small. Before contributing, please read the [code of conduct](https://github.com/EthWorks/useDapp/blob/master/CODE_OF_CONDUCT.md) and [contribution policy](https://github.com/EthWorks/useDapp/blob/master/CONTRIBUTION.md).
+
+## License
+
+useDapp is released under the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Add coingecko package readme to display in npm package page https://www.npmjs.com/package/@usedapp/coingecko

refer from https://github.com/EthWorks/useDApp/blob/master/packages/core/README.md
the document is linked to https://usedapp.readthedocs.io/en/latest/coingecko.html