### PR TITLE
fix(devtools): Adding a check for window object

### DIFF
--- a/.changeset/modern-colts-knock.md
+++ b/.changeset/modern-colts-knock.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+fix(devtools): Adding a check for window object

--- a/packages/core/src/providers/devtools.ts
+++ b/packages/core/src/providers/devtools.ts
@@ -65,7 +65,10 @@ type Notification =
   | MulticallError
   | GenericError
 
-const hook: any = (window as any).__USEDAPP_DEVTOOLS_HOOK__
+let hook: any
+if (typeof window !== 'undefined') {
+  hook = (window as any).__USEDAPP_DEVTOOLS_HOOK__
+}
 
 // immediately notify devtools that the page is using it
 notifyDevtools({ type: 'INIT' })


### PR DESCRIPTION
Adds a check to see if `window` is defined, which prevents an error on Next.js due to server side rendering.