### PR TITLE
Memoize hook return values to prevent unnecessary re-renders

### DIFF
--- a/.changeset/chilly-timers-chew.md
+++ b/.changeset/chilly-timers-chew.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Memoize hook return values to prevent unnecessary re-renders

--- a/.changeset/nice-buttons-sit.md
+++ b/.changeset/nice-buttons-sit.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Memoize hook return values to prevent unnecessary re-renders

--- a/.changeset/nice-buttons-sit.md
+++ b/.changeset/nice-buttons-sit.md
@@ -1,5 +1,0 @@
----
-"@usedapp/core": patch
----
-
-Memoize hook return values to prevent unnecessary re-renders

--- a/packages/core/src/hooks/useChainCalls.ts
+++ b/packages/core/src/hooks/useChainCalls.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useMemo } from 'react'
 import { ChainCall } from '../providers/chainState/callsReducer'
 import { ChainStateContext } from '../providers/chainState/context'
 import { Falsy } from '../model/types'
@@ -12,7 +12,10 @@ export function useChainCalls(calls: (ChainCall | Falsy)[]) {
     return () => dispatchCalls({ type: 'REMOVE_CALLS', calls: filteredCalls })
   }, [JSON.stringify(calls), dispatchCalls])
 
-  return calls.map((call) => call && value?.state?.[call.address]?.[call.data])
+  return useMemo(() => calls.map((call) => call && value?.state?.[call.address]?.[call.data]), [
+    JSON.stringify(calls),
+    value,
+  ])
 }
 
 export function useChainCall(call: ChainCall | Falsy) {

--- a/packages/core/src/hooks/useContractFunction.ts
+++ b/packages/core/src/hooks/useContractFunction.ts
@@ -1,6 +1,7 @@
 import { TransactionOptions } from '../../src'
 import { Contract } from '@ethersproject/contracts'
 import { Web3Provider } from '@ethersproject/providers'
+import { useCallback } from 'react'
 import { useEthers } from './useEthers'
 import { usePromiseTransaction } from './usePromiseTransaction'
 
@@ -24,10 +25,13 @@ export function useContractFunction(contract: Contract, functionName: string, op
   const { library, chainId } = useEthers()
   const { promiseTransaction, state } = usePromiseTransaction(chainId, options)
 
-  const send = async (...args: any[]) => {
-    const contractWithSigner = connectContractToSigner(contract, options, library)
-    await promiseTransaction(contractWithSigner[functionName](...args))
-  }
+  const send = useCallback(
+    async (...args: any[]) => {
+      const contractWithSigner = connectContractToSigner(contract, options, library)
+      await promiseTransaction(contractWithSigner[functionName](...args))
+    },
+    [contract, functionName, options, library]
+  )
 
   return { send, state }
 }

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -1,5 +1,5 @@
 import { TransactionResponse } from '@ethersproject/abstract-provider'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTransactionsContext } from '../providers'
 import { TransactionStatus, TransactionOptions } from '../../src'
 
@@ -7,29 +7,33 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
   const [state, setState] = useState<TransactionStatus>({ status: 'None' })
   const { addTransaction } = useTransactionsContext()
 
-  const promiseTransaction = async (transactionPromise: Promise<TransactionResponse>) => {
-    if (!chainId) return
-    let transaction: TransactionResponse | undefined = undefined
-    try {
-      transaction = await transactionPromise
+  const promiseTransaction = useCallback(
+    async (transactionPromise: Promise<TransactionResponse>) => {
+      if (!chainId) return
+      let transaction: TransactionResponse | undefined = undefined
+      try {
+        transaction = await transactionPromise
 
-      setState({ transaction, status: 'Mining', chainId })
-      addTransaction({
-        transaction,
-        submittedAt: Date.now(),
-        transactionName: options?.transactionName,
-      })
-      const receipt = await transaction.wait()
+        setState({ transaction, status: 'Mining', chainId })
+        addTransaction({
+          transaction,
+          submittedAt: Date.now(),
+          transactionName: options?.transactionName,
+        })
+        const receipt = await transaction.wait()
 
-      setState({ receipt, transaction, status: 'Success', chainId })
-    } catch (e) {
-      const errorMessage = e.reason ?? e.message
-      if (transaction) {
-        setState({ status: 'Fail', transaction, receipt: e.receipt, errorMessage, chainId })
-      } else {
-        setState({ status: 'Exception', errorMessage, chainId })
+        setState({ receipt, transaction, status: 'Success', chainId })
+      } catch (e) {
+        const errorMessage = e.reason ?? e.message
+        if (transaction) {
+          setState({ status: 'Fail', transaction, receipt: e.receipt, errorMessage, chainId })
+        } else {
+          setState({ status: 'Exception', errorMessage, chainId })
+        }
       }
-    }
-  }
+    },
+    [chainId, setState, addTransaction, options]
+  )
+
   return { promiseTransaction, state }
 }


### PR DESCRIPTION
Fixes #280 causing certain hooks to update on any parent component re-render because return values were not being memoized in any way.

Passes all tests and confirmed it fixes the issues as far as I could see