### PR TITLE
feat: better error messaging

### DIFF
--- a/.changeset/light-walls-explode.md
+++ b/.changeset/light-walls-explode.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': patch
+---
+
+Use error messages from RPC client if available

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -23,7 +23,7 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
 
       setState({ receipt, transaction, status: 'Success', chainId })
     } catch (e) {
-      const errorMessage = e.reason ?? e.message
+      const errorMessage = e.error?.message ?? e.reason ?? e.message
       if (transaction) {
         setState({ status: 'Fail', transaction, receipt: e.receipt, errorMessage, chainId })
       } else {


### PR DESCRIPTION
Check for the existence of rpc error messages and use them, this prevents the mass "cannot estimate gas" messaging for errors that aren't related to gas.

Fixes https://github.com/EthWorks/useDApp/issues/260