### PR TITLE
Fix: handle lookupAddress errors

### DIFF
--- a/.changeset/grumpy-items-wonder.md
+++ b/.changeset/grumpy-items-wonder.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': patch
+---
+
+Catch lookupAddress errors for unsupported chains, e.g. Matic

--- a/packages/core/src/hooks/useLookupAddress.ts
+++ b/packages/core/src/hooks/useLookupAddress.ts
@@ -3,17 +3,20 @@ import { useEthers } from './useEthers'
 
 export function useLookupAddress() {
   const { account, library } = useEthers()
-  const [ens, setEns] = useState<string>()
+  const [ens, setEns] = useState<string | null>()
 
   useEffect(() => {
     let mounted = true
 
     if (account && library) {
-      library?.lookupAddress(account).then((name) => {
-        if (mounted) {
-          setEns(name)
-        }
-      })
+      library
+        ?.lookupAddress(account)
+        .then((name) => {
+          if (mounted) {
+            setEns(name)
+          }
+        })
+        .catch(() => setEns(null))
     }
 
     return () => {


### PR DESCRIPTION
Networks like matic don't have ens lookup and throw errors on the application when checking