### PR TITLE
feat: filter contract logs for events

### DIFF
--- a/.changeset/eighty-worms-itch.md
+++ b/.changeset/eighty-worms-itch.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': minor
+---
+
+Prevent crash when parsing transaction logs from contract call

--- a/packages/core/src/hooks/useContractFunction.ts
+++ b/packages/core/src/hooks/useContractFunction.ts
@@ -31,17 +31,11 @@ export function useContractFunction(contract: Contract, functionName: string, op
     async (...args: any[]) => {
       const contractWithSigner = connectContractToSigner(contract, options, library)
       const receipt = await promiseTransaction(contractWithSigner[functionName](...args))
-      if (receipt) {
-        if (receipt.logs && receipt.logs.length > 0) {
-          setEvents(receipt.logs.reduce<LogDescription[]>((result, log) => {
-            if (log.address === contract.address) {
-              result.push(contract.interface.parseLog(log))
-            }
-            return result
-          }, []))
-        } else {
-          setEvents([])
-        }
+      if (receipt?.logs) {
+        const events = receipt.logs
+          .filter((log) => log.address === contract.address)
+          .map((log) => contract.interface.parseLog(log))
+        setEvents(events)
       }
     },
     [contract, functionName, options, library]

--- a/packages/core/src/hooks/useContractFunction.ts
+++ b/packages/core/src/hooks/useContractFunction.ts
@@ -33,7 +33,12 @@ export function useContractFunction(contract: Contract, functionName: string, op
       const receipt = await promiseTransaction(contractWithSigner[functionName](...args))
       if (receipt) {
         if (receipt.logs && receipt.logs.length > 0) {
-          setEvents(receipt.logs.map((log) => contract.interface.parseLog(log)))
+          setEvents(receipt.logs.reduce<LogDescription[]>((result, log) => {
+            if (log.address === contract.address) {
+              result.push(contract.interface.parseLog(log))
+            }
+            return result
+          }, []))
         } else {
           setEvents([])
         }


### PR DESCRIPTION
### Description of changes
Avoid `No Matching event` by only calling `parseLog` on the logs that correspond to the current contract called.

### Notes:
I'm not sure if this is the best solution for the problem, ideally we should return the logs unparsed but that can be found in the transaction itself