### PR TITLE
feat: improve errorMessage on transaction error

### DIFF
--- a/.changeset/hip-weeks-prove.md
+++ b/.changeset/hip-weeks-prove.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': minor
+---
+
+Improve errorMessage from a contract call

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -24,7 +24,7 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
         setState({ receipt, transaction, status: 'Success', chainId })
         return receipt
       } catch (e) {
-        const errorMessage = e.error?.message ?? e.reason ?? e.message
+        const errorMessage = e.error?.message ?? e.reason ?? e.data?.message ?? e.message
         if (transaction) {
           setState({ status: 'Fail', transaction, receipt: e.receipt, errorMessage, chainId })
         } else {


### PR DESCRIPTION
### Description of changes
- Checks for `e.data.message` when a transaction fails, currently it just returns `Internal JSON-RPC error`

**Returned error example**
![example](https://puu.sh/I3B0r/0484f60dd7.png)