### PR TITLE
Add workaround for current metamask chainId bug

### DIFF
--- a/.changeset/seven-buckets-trade.md
+++ b/.changeset/seven-buckets-trade.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Use currently connected network as chainId for transactions

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -16,7 +16,10 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
 
         setState({ transaction, status: 'Mining', chainId })
         addTransaction({
-          transaction,
+          transaction: {
+            ...transaction,
+            chainId: chainId,
+          },
           submittedAt: Date.now(),
           transactionName: options?.transactionName,
         })


### PR DESCRIPTION
Currently there is a bug with metamask which results in chainId in transaction being always 0.
https://github.com/MetaMask/metamask-extension/issues/11892

I don't yet know how should we handle it (it may changed after EIP-1559?)