### PR TITLE
docs: add missing imports in getting-started.rst

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -29,7 +29,7 @@ Below is a simple example:
 
 .. code-block:: javascript
 
-  import { ChainId, DAppProvider } from '@usedapp/core'
+  import { ChainId, DAppProvider, useEtherBalance, useEthers } from '@usedapp/core'
 
   const config: Config = {
     readOnlyChainId: ChainId.Mainnet,


### PR DESCRIPTION
I found out how to import the `useEthersBalance` and the `useEthers` hooks from the [Balance.tsx](https://github.com/EthWorks/useDApp/blob/d2ce1ab9b608d8683f12d7ff2c2c17baaf7df2db/packages/example/src/pages/Balance.tsx) component in the example project.