### PR TITLE
Add missing import for "formatEther" in example

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -30,6 +30,7 @@ Below is a simple example:
 .. code-block:: javascript
 
   import { ChainId, DAppProvider, useEtherBalance, useEthers } from '@usedapp/core'
+  import { formatEther } from '@ethersproject/units'
 
   const config: Config = {
     readOnlyChainId: ChainId.Mainnet,


### PR DESCRIPTION
I was slightly confused in the very first example about where "formatEther" was coming from :)