### PR TITLE
Don't break SSR apps with Coingecko hook

### DIFF
--- a/.changeset/calm-weeks-move.md
+++ b/.changeset/calm-weeks-move.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/coingecko": patch
+---
+
+Don't break SSR apps with Coingecko hook

--- a/packages/coingecko/src/simple_price.ts
+++ b/packages/coingecko/src/simple_price.ts
@@ -20,4 +20,4 @@ export const fetchCoingeckoPrice = (fetchFunction: any) => async (base: string, 
   }
 }
 
-export const getCoingeckoPrice = fetchCoingeckoPrice(window && window.fetch)
+export const getCoingeckoPrice = fetchCoingeckoPrice(typeof window !== 'undefined' && window.fetch)

--- a/packages/coingecko/src/simple_token_price.ts
+++ b/packages/coingecko/src/simple_token_price.ts
@@ -26,4 +26,4 @@ export const fetchCoingeckoTokenPrice = (fetchFunction: any) => async (
   }
 }
 
-export const getCoingeckoTokenPrice = fetchCoingeckoTokenPrice(window && window.fetch)
+export const getCoingeckoTokenPrice = fetchCoingeckoTokenPrice(typeof window !== 'undefined' && window.fetch)


### PR DESCRIPTION
Using the coingecko package currently breaks your app if you use a SSR framework like [Next.js](https://nextjs.org)

<img width="1025" alt="Screenshot 2021-09-12 at 18 02 40" src="https://user-images.githubusercontent.com/2598660/132996821-ab81a581-4b88-45f7-9931-031929c53d2d.png">

This PR is a simple fix to ensure that `window` doesn't get evaluated if it doesn't exist in the environment that the code is run in.

### Possible alternative solutions:
Use [isomorphic-fetch](https://www.npmjs.com/package/isomorphic-fetch) so that the price can be fetched both client-side and server-side? This would however introduce another dependency to the project.