### PR TITLE
↔️ Feat: handle dropped and replaced transactions

### DIFF
--- a/.changeset/four-snails-change.md
+++ b/.changeset/four-snails-change.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': patch
+---
+
+Handle dropped and replaced transactions

--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -367,6 +367,7 @@ Each can be one of the following:
   {
     type: 'transactionSucceed'
     transaction: TransactionResponse
+    originalTransaction?: TransactionResponse
     receipt: TransactionReceipt
     transactionName?: string
   }
@@ -376,6 +377,7 @@ Each can be one of the following:
   {
     type: 'transactionFailed'
     transaction: TransactionResponse
+    originalTransaction?: TransactionResponse
     receipt: TransactionReceipt
     transactionName?: string
   }
@@ -457,6 +459,7 @@ Each transaction has following type:
     receipt?: TransactionReceipt
     lastCheckedBlockNumber?: number
     transactionName?: string
+    originalTransaction?: TransactionResponse
   }
 
 Link to: `Transaction Response <https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse>`_.
@@ -639,6 +642,8 @@ Fields:
 - ``status: TransactionState`` - string that can contain one of ``None`` ``Mining`` ``Success`` ``Fail`` ``Exception``
 
 - ``transaction?: TransactionResponse`` - optional field. See `Transaction Response <https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse>`_.
+
+- ``originalTransaction?: TransactionResponse`` - optional field that contains the original transaction if it has been dropped and replaced. See `Transaction Response <https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse>`_.
 
 - ``receipt?: TransactionReceipt`` - optional field. See `Transaction Receipt <https://docs.ethers.io/v5/api/providers/types/#providers-TransactionReceipt>`_.
 

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -3,9 +3,10 @@ import { useCallback, useState } from 'react'
 import { useNotificationsContext, useTransactionsContext } from '../providers'
 import { TransactionStatus, TransactionOptions } from '../../src'
 import { TransactionState } from '../model'
+import { errors } from 'ethers'
 
 const isDroppedAndReplaced = (e: any) =>
-  e?.code === 'TRANSACTION_REPLACED' && e?.replacement && (e?.reason === 'repriced' || e?.cancelled === false)
+  e?.code === errors.TRANSACTION_REPLACED && e?.replacement && (e?.reason === 'repriced' || e?.cancelled === false)
 
 export function usePromiseTransaction(chainId: number | undefined, options?: TransactionOptions) {
   const [state, setState] = useState<TransactionStatus>({ status: 'None' })

--- a/packages/core/src/model/TransactionStatus.ts
+++ b/packages/core/src/model/TransactionStatus.ts
@@ -9,6 +9,7 @@ export interface TransactionStatus {
   receipt?: TransactionReceipt
   chainId?: ChainId
   errorMessage?: string
+  originalTransaction?: TransactionResponse
 }
 
 export function transactionErrored(transaction: TransactionStatus) {

--- a/packages/core/src/providers/notifications/model.ts
+++ b/packages/core/src/providers/notifications/model.ts
@@ -8,12 +8,14 @@ type NotificationPayload = { submittedAt: number } & (
       transaction: TransactionResponse
       receipt: TransactionReceipt
       transactionName?: string
+      originalTransaction?: TransactionResponse
     }
   | {
       type: 'transactionFailed'
       transaction: TransactionResponse
       receipt: TransactionReceipt
       transactionName?: string
+      originalTransaction?: TransactionResponse
     }
   | { type: 'walletConnected'; address: string }
 )

--- a/packages/core/src/providers/transactions/model.ts
+++ b/packages/core/src/providers/transactions/model.ts
@@ -7,6 +7,7 @@ export interface StoredTransaction {
   receipt?: TransactionReceipt
   lastCheckedBlockNumber?: number
   transactionName?: string
+  originalTransaction?: TransactionResponse
 }
 
 export function getStoredTransactionState(transaction: StoredTransaction) {


### PR DESCRIPTION
Currently if a user speeds up a transaction the old transaction will report as failed and the new one will not exist in useDapp state. This change adds some handling around the failed transaction to check if it was replaced and repriced and should therefore continue on as a new pending transaction.

Would really appreciate any feedback on this. We're currently using a similarly updated version of useContractFunction in prod on NFTX.