### PR TITLE
Added Config import to example code

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -29,7 +29,7 @@ Below is a simple example:
 
 .. code-block:: javascript
 
-  import { ChainId, DAppProvider, useEtherBalance, useEthers } from '@usedapp/core'
+  import { ChainId, DAppProvider, useEtherBalance, useEthers, Config } from '@usedapp/core'
   import { formatEther } from '@ethersproject/units'
 
   const config: Config = {


### PR DESCRIPTION
Adding the `Config` type to the `@usedapp/core` import within the Example section of Getting Started. 

It'd be nice if these Cmd + c lines were good to go :p
 
![moonderek-getting-started-add-Config-type](https://user-images.githubusercontent.com/52265864/137049312-e619457b-76e0-4611-a940-f91b378b0850.png)
