### PR TITLE
🦞 Skip multicall if address is undefined

### DIFF
--- a/.changeset/funny-wolves-learn.md
+++ b/.changeset/funny-wolves-learn.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+🦞 Skip multicall if address is undefined

--- a/packages/core/src/hooks/useContractCall.ts
+++ b/packages/core/src/hooks/useContractCall.ts
@@ -11,8 +11,12 @@ function warnOnInvalidContractCall(call: ContractCall | Falsy) {
 }
 
 function encodeCallData(call: ContractCall | Falsy): ChainCall | Falsy {
+  if (!call || !call.address || !call.method) {
+    warnOnInvalidContractCall(call)
+    return undefined
+  }
   try {
-    return call && { address: call.address, data: call.abi.encodeFunctionData(call.method, call.args) }
+    return { address: call.address, data: call.abi.encodeFunctionData(call.method, call.args) }
   } catch {
     warnOnInvalidContractCall(call)
     return undefined


### PR DESCRIPTION
We had some nasty debugging when all useDapp calls stoped working after switching to Ropsten. Turns out, one of addresses was undefined for ropsten and all we got was Invalid ENS Name error in console. 

**Maybe we should also test if address has correct format to handle this better?**