### PR TITLE
useDisplayName => useLookupAddress

### DIFF
--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -478,7 +478,7 @@ useLookupAddress
 .. code-block:: javascript
 
   const { account } = useEthers()
-  const ens = useDisplayName()
+  const ens = useLookupAddress()
 
   return (
     <p>Account: {ens ?? account}</p>


### PR DESCRIPTION
I think the former name is a mistake b/c I don't see it exported in the API. I can use `useLookupAddress()`