### PR TITLE
Make persistent connection optional

### DIFF
--- a/packages/core/src/model/config/Config.ts
+++ b/packages/core/src/model/config/Config.ts
@@ -12,6 +12,7 @@ export type FullConfig = {
   readOnlyChainId?: ChainId
   readOnlyUrls?: NodeUrls
   multicallAddresses?: MulticallAddresses
+  persistConnection?: boolean
   supportedChains: number[]
   pollingInterval?: number
   notifications: {

--- a/packages/core/src/providers/NetworkActivator.tsx
+++ b/packages/core/src/providers/NetworkActivator.tsx
@@ -6,7 +6,7 @@ import { useConfig } from './config/context'
 
 export function NetworkActivator() {
   const { activate, account, chainId: connectedChainId, active, connector } = useEthers()
-  const { supportedChains, readOnlyChainId, readOnlyUrls } = useConfig()
+  const { supportedChains, readOnlyChainId, readOnlyUrls, persistConnection } = useConfig()
 
   useEffect(() => {
     const eagerConnect = async () => {
@@ -15,7 +15,10 @@ export function NetworkActivator() {
         activate(injected)
       }
     }
-    eagerConnect()
+
+    if (persistConnection) {
+      eagerConnect()
+    }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
Eventually it would be good to have a last-enabled provider persistence, but requiring the injected provider to persist makes implementation more difficult.