### PR TITLE
fix isLocalChain warning in local development

### DIFF
--- a/.changeset/gentle-hairs-smoke.md
+++ b/.changeset/gentle-hairs-smoke.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Use isLocalChain Chain property instead of function

--- a/packages/core/src/providers/LocalMulticallProvider.tsx
+++ b/packages/core/src/providers/LocalMulticallProvider.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useState } from 'react'
-import { isLocalChain } from '../helpers'
+import { getChainById } from '../helpers'
 import { useEthers } from '../hooks'
 import { useBlockNumber } from './blockNumber'
 import { useConfig, useUpdateConfig } from './config'
@@ -29,7 +29,7 @@ export function LocalMulticallProvider({ children }: LocalMulticallProps) {
   useEffect(() => {
     if (!library || !chainId) {
       setLocalMulticallState(LocalMulticallState.Unknown)
-    } else if (!isLocalChain(chainId)) {
+    } else if (!getChainById(chainId)?.isLocalChain) {
       setLocalMulticallState(LocalMulticallState.NonLocal)
     } else if (multicallAddresses && multicallAddresses[chainId]) {
       setLocalMulticallState(LocalMulticallState.Deployed)


### PR DESCRIPTION
due to `LocalMulticallProvider` still use the `isLocalChain` helper

isLocalChain warning is shown while run `yarn start` for the example
