### PR TITLE
Add PendingSignature transaction state

### DIFF
--- a/.changeset/dirty-worms-clean.md
+++ b/.changeset/dirty-worms-clean.md
@@ -1,0 +1,5 @@
+---
+'@usedapp/core': minor
+---
+
+Add PendingSignature TransactionState for transactions that are pending signature. This gets set on each new transaction function call and clears out the previous error when new attempts are made.

--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -777,6 +777,7 @@ Fields:
 ``status`` can be one of the following:
 
 - **None** - before a transaction is created.
+- **PendingSignature** - when a transaction has been initiated, but requires signature.
 - **Mining** - when a transaction is sent to the network, but not yet mined. In this state ``transaction: TransactionResponse`` is available.
 - **Success** - when a transaction has been mined successfully. In this state ``transaction: TransactionResponse`` and ``receipt: TransactionReceipt`` are available.
 - **Failed** - when a transaction has been mined, but ended up reverted. Again ``transaction: TransactionResponse`` and ``receipt: TransactionReceipt`` are available.

--- a/packages/core/src/hooks/usePromiseTransaction.ts
+++ b/packages/core/src/hooks/usePromiseTransaction.ts
@@ -18,6 +18,8 @@ export function usePromiseTransaction(chainId: number | undefined, options?: Tra
       if (!chainId) return
       let transaction: TransactionResponse | undefined = undefined
       try {
+        setState({ status: 'PendingSignature', chainId })
+
         transaction = await transactionPromise
 
         setState({ transaction, status: 'Mining', chainId })

--- a/packages/core/src/model/TransactionStatus.ts
+++ b/packages/core/src/model/TransactionStatus.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '../constants'
 import { TransactionResponse, TransactionReceipt } from '@ethersproject/abstract-provider'
 
-export type TransactionState = 'None' | 'Mining' | 'Success' | 'Fail' | 'Exception'
+export type TransactionState = 'None' | 'PendingSignature' | 'Mining' | 'Success' | 'Fail' | 'Exception'
 
 export interface TransactionStatus {
   status: TransactionState


### PR DESCRIPTION
* Add `PendingSignature` to TransactionState. (See the "Waiting on Signature..." disabled button in the screen shot. This PR makes this possible)
* Set `PendingSignature` state before each transaction begins so that errorMessages are reset on a new attempt

<img width="752" alt="Screen Shot 2022-01-07 at 5 14 48 PM" src="https://user-images.githubusercontent.com/2101499/148614324-263e9212-8722-4bb9-af69-276842e440b4.png">
 