### PR TITLE
Fix peer dependency conflict

### DIFF
--- a/.changeset/violet-turkeys-sleep.md
+++ b/.changeset/violet-turkeys-sleep.md
@@ -1,0 +1,6 @@
+---
+"@usedapp/example": patch
+---
+
+Fix peer dependency conflict:
+- update @pmmmwh/react-refresh-webpack-plugin

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -22,7 +22,7 @@
     "styled-components": "^5.2.1"
   },
   "devDependencies": {
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.4",
     "@testing-library/react": "^11.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",


### PR DESCRIPTION
Currently `npm install` in the example package leads to a peer dependency conflict due to `react-refresh@^0.10.0,` in the package.json being specificed but `@pmmmwh/react-refresh-webpack-plugin@^0.4.3` requiring `react-refresh@">=0.8.3 <0.10.0"`. 

This fixes the example package.