### PR TITLE
fix(Web3ModalButton): catch web3modal connect errors

### DIFF
--- a/packages/example/src/components/account/Web3ModalButton.tsx
+++ b/packages/example/src/components/account/Web3ModalButton.tsx
@@ -45,7 +45,7 @@ export const Web3ModalButton = () => {
       const provider = await web3Modal.connect()
       await activate(provider)
     } catch(error: any) {
-      setActivateError(error?.message)
+      setActivateError(error.message)
     }
   }
 

--- a/packages/example/src/components/account/Web3ModalButton.tsx
+++ b/packages/example/src/components/account/Web3ModalButton.tsx
@@ -44,6 +44,7 @@ export const Web3ModalButton = () => {
     try {
       const provider = await web3Modal.connect()
       await activate(provider)
+      setActivateError('')
     } catch (error: any) {
       setActivateError(error.message)
     }

--- a/packages/example/src/components/account/Web3ModalButton.tsx
+++ b/packages/example/src/components/account/Web3ModalButton.tsx
@@ -44,7 +44,7 @@ export const Web3ModalButton = () => {
     try {
       const provider = await web3Modal.connect()
       await activate(provider)
-    } catch(error: any) {
+    } catch (error: any) {
       setActivateError(error.message)
     }
   }

--- a/packages/example/src/components/account/Web3ModalButton.tsx
+++ b/packages/example/src/components/account/Web3ModalButton.tsx
@@ -41,8 +41,12 @@ export const Web3ModalButton = () => {
     const web3Modal = new Web3Modal({
       providerOptions,
     })
-    const provider = await web3Modal.connect()
-    await activate(provider)
+    try {
+      const provider = await web3Modal.connect()
+      await activate(provider)
+    } catch(error: any) {
+      setActivateError(error?.message)
+    }
   }
 
   return (


### PR DESCRIPTION
Catches unhandled web3modal connection errors and places them into activation error position

Behaviour before handling the error:

https://user-images.githubusercontent.com/14224459/151959098-7ba79c2a-5f78-4271-9fa3-f0c7ac89855b.mp4

Behaviour after handling the error:

https://user-images.githubusercontent.com/14224459/151959128-0744c94a-2f1f-4dca-a688-52d2f6596074.mp4

This also works for other wallet connection options provided to web3modal (please ignore that I haven't set an image for the Coinbase wallet option):

https://user-images.githubusercontent.com/14224459/151959503-97809b16-5d58-4f32-ae23-d57cc1d481f4.mp4
