### PR TITLE
📝 Add eslint-plugin-react-hooks

### DIFF
--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.json",
+    "plugin:react-hooks/recommended"
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "7.19.0",
+    "eslint-plugin-react-hooks": "^4.3.0",
     "ethereum-waffle": "^3.2.2",
     "jsdom": "^16.4.0",
     "jsdom-global": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7793,6 +7793,11 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-react-hooks@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz#318dbf312e06fab1c835a4abef00121751ac1172"
+  integrity sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
Official react hooks eslint plugin.

Found 26 new warnings that need to be addressed