### PR TITLE
🔵 Update Base RPC url

### DIFF
--- a/.changeset/heavy-fishes-whisper.md
+++ b/.changeset/heavy-fishes-whisper.md
@@ -1,0 +1,5 @@
+---
+"@usedapp/core": patch
+---
+
+Update Base RPC url

--- a/packages/core/src/model/chain/base.ts
+++ b/packages/core/src/model/chain/base.ts
@@ -28,7 +28,7 @@ export const Base: Chain = {
   isTestChain: false,
   isLocalChain: false,
   multicallAddress: '0x38641b7a50CDcfde75a7A83eB7c02581F3279362',
-  rpcUrl: 'https://base.org',
+  rpcUrl: 'https://mainnet.base.org',
   nativeCurrency: {
     name: 'Ether',
     symbol: 'ETH',


### PR DESCRIPTION
Fixes: #1172 

TLDR: Base Mainnet RPC is wrong, this causes issues adding the Base network via the `switchNetwork` function. PR updates it to the correct RPC from their docs: https://docs.base.org/docs/network-information/